### PR TITLE
Add a Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 **/build
 /tests/**/output
+
+# Nix builds
+result

--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1704039270,
-        "narHash": "sha256-L/K76xsyEPIqOK0mfDLBf6z0LDN5H3cHFgxqmZA05Hs=",
-        "owner": "mattpolzin",
+        "lastModified": 1704491951,
+        "narHash": "sha256-T1BP4QwbsMVIaTvjQCZvwXp2PwqycnpR6krsf0LUGx4=",
+        "owner": "idris-lang",
         "repo": "Idris2",
-        "rev": "2ff3bfcad31684f4dad3ac63f089a00808daa756",
+        "rev": "8746f1671b14ac80c1b986a7a5679fa9e556fc25",
         "type": "github"
       },
       "original": {
-        "owner": "mattpolzin",
-        "ref": "nix-idrisapi",
+        "owner": "idris-lang",
         "repo": "Idris2",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "idris": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "idris-emacs-src": "idris-emacs-src",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1704039270,
+        "narHash": "sha256-L/K76xsyEPIqOK0mfDLBf6z0LDN5H3cHFgxqmZA05Hs=",
+        "owner": "mattpolzin",
+        "repo": "Idris2",
+        "rev": "2ff3bfcad31684f4dad3ac63f089a00808daa756",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mattpolzin",
+        "ref": "nix-idrisapi",
+        "repo": "Idris2",
+        "type": "github"
+      }
+    },
+    "idris-emacs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1666078909,
+        "narHash": "sha256-oYNHFIpcrFfPb4sXJwEBFKeH+PB4AGCrAFrfBrSTCeo=",
+        "owner": "redfish64",
+        "repo": "idris2-mode",
+        "rev": "3bcb52a65c488f31c99d20f235f6050418a84c9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "redfish64",
+        "repo": "idris2-mode",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1671864851,
+        "narHash": "sha256-Z3L5MSWOyTdVTIVBrLEh2HwgDYGcqf1gnGYFx+7gb/k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "27392c3cb3ddc39123426aa88fe186aa0ea1c253",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1704060006,
+        "narHash": "sha256-DJqxVZf35Gaw07Vt0qT1cS0pqfzZiuB+WfLTJNJdbgY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e5af05cbf33cf3d4148a4a1ce6cab1c5fb8fec09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "idris": "idris",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -19,7 +19,9 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "idris-emacs-src": "idris-emacs-src",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1704491951,
@@ -53,21 +55,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671864851,
-        "narHash": "sha256-Z3L5MSWOyTdVTIVBrLEh2HwgDYGcqf1gnGYFx+7gb/k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "27392c3cb3ddc39123426aa88fe186aa0ea1c253",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
         "lastModified": 1704060006,
         "narHash": "sha256-DJqxVZf35Gaw07Vt0qT1cS0pqfzZiuB+WfLTJNJdbgY=",
         "owner": "nixos",
@@ -84,7 +71,7 @@
     "root": {
       "inputs": {
         "idris": "idris",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs";
 
     idris.url = "github:idris-lang/Idris2";
+    idris.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, nixpkgs, idris }:

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs";
 
-    # tmp url:
-    idris.url = "github:mattpolzin/Idris2/nix-idrisapi";
+    idris.url = "github:idris-lang/Idris2";
   };
 
   outputs = { self, nixpkgs, idris }:
@@ -16,7 +15,6 @@
     in
     { packages = lib.genAttrs systems (system:
       let
-        idrisPkgs = idris.packages.${system};
         buildIdris = idris.buildIdris.${system};
 
         lspLibPkg = buildIdris {
@@ -26,6 +24,7 @@
         };
       in rec {
         lsp-lib = lspLibPkg.library { };
+        lsp-lib-with-src = lspLibPkg.library { withSource = true; };
         default = lsp-lib;
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Library for building out LSPs";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+
+    # tmp url:
+    idris.url = "github:mattpolzin/Idris2/nix-idrisapi";
+  };
+
+  outputs = { self, nixpkgs, idris }:
+    let
+      lib = nixpkgs.lib;
+      # support the same systems as Idris2
+      systems = builtins.attrNames idris.packages;
+    in
+    { packages = lib.genAttrs systems (system:
+      let
+        idrisPkgs = idris.packages.${system};
+        buildIdris = idris.buildIdris.${system};
+
+        lspLibPkg = buildIdris {
+          projectName = "LSP-lib";
+          src = ./.;
+          idrisLibraries = [ ];
+        };
+      in rec {
+        lsp-lib = lspLibPkg.library { };
+        default = lsp-lib;
+      }
+    );
+  };
+}


### PR DESCRIPTION
This makes it just slightly easier to use the LSP-lib as a flake input to the `idris2-lsp` project (or any other project wanting to offer a Nix flake).

I have a flake PR for `idris2-lsp` ready in wait.