### PR TITLE
Fix capitalization of `projectName` in Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         buildIdris = idris.buildIdris.${system};
 
         lspLibPkg = buildIdris {
-          projectName = "LSP-lib";
+          projectName = "lsp-lib";
           src = ./.;
           idrisLibraries = [ ];
         };


### PR DESCRIPTION
`buildIdris` was looking for `LSP-lib.ipkg`, which does not exist.

This fixes #4.